### PR TITLE
address CVE-2017-17042, remove unsupported ruby versions, and use `sensu-plugin` 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
 notifications:
@@ -29,8 +27,6 @@ deploy:
   gem: sensu-plugins-azurerm
   on:
     tags: true
-    rvm: 2.1
-    rvm: 2.2
     rvm: 2.3.0
     rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-azurerm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+### Security
+- updated `yard` dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 which closes attacks against a yard server loading arbitrary files (@majormoses)
+
+### Breaking Changes
+- removed ruby support for `< 2.3` (@majormoses)
+
+### Changed
+- bumped minumum dependency of `sensu-plugin` to 2.5 (@majormoses)
+
 ## [2.1.0] - 2018-09-10
 ### Added
 - check-azurerm-monitor-metric.rb: allows you to check against azure metric thresholds for a particular resource id or name (@thomaslitton)

--- a/sensu-plugins-azurerm.gemspec
+++ b/sensu-plugins-azurerm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.3.0'
   s.summary                = 'Sensu plugins for working with an Azure Resource Manager environment'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsAzureRM::Version::VER_STRING
@@ -31,7 +31,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'azure_mgmt_network', '0.8.0'
   s.add_runtime_dependency 'azure_mgmt_service_bus', '0.8.0'
   s.add_runtime_dependency 'ms_rest_azure',      '~> 0.6.2'
-  s.add_runtime_dependency 'sensu-plugin',       '~> 2.0'
+  s.add_runtime_dependency 'sensu-plugin',       '~> 2.5'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -49,5 +49,5 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'serverspec',                '~> 2.36.1'
   s.add_development_dependency 'test-kitchen',              '~> 1.6'
   s.add_development_dependency 'webmock',                   '~> 3.1'
-  s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'yard',                      '~> 0.9.11'
 end

--- a/test/integration/ruby-21/serverspec/default_spec.rb
+++ b/test/integration/ruby-21/serverspec/default_spec.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-require 'spec_helper'
-require 'shared_spec'

--- a/test/integration/ruby-22/serverspec/default_spec.rb
+++ b/test/integration/ruby-22/serverspec/default_spec.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-require 'spec_helper'
-require 'shared_spec'


### PR DESCRIPTION
CVE:
- https://nvd.nist.gov/vuln/detail/CVE-2017-17042

Breaking Changes
- remove `< 2.3.0` ruby version support

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

- https://github.com/sensu-plugins/community/issues/97

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Cleanup: CVE, removing unsupported ruby versions, use latest `sensu-plugin` 

#### Known Compatibility Issues
removes ruby `< 2.3` version